### PR TITLE
Added LG to network configuration

### DIFF
--- a/flexible_load_analysis/objects/network.py
+++ b/flexible_load_analysis/objects/network.py
@@ -178,7 +178,7 @@ def add_node(dict_network, n_node, n_parent_node):
     dict_bus['ZONE'] = np.append(dict_bus['ZONE'],'1')
     dict_bus['VMAX'] = np.append(dict_bus['VMAX'],'1.04')
     dict_bus['VMIN'] = np.append(dict_bus['VMIN'],'0.96')
-
+    dict_bus['LG'] = np.append(dict_bus['LG'], '0')  
     dict_branch = dict_network['branch']
 
     # Adding the branch to the dictionary of branches


### PR DESCRIPTION
Added "LG" as a column/ parameter in the bus configuration which represents the local generation capability (Local reserves) at a given node. The default values are set to 0 (no reserves) and can later be overwritten (if needed) when configuring the network.